### PR TITLE
Harden mp-test workflow for clean static self-hosted runners

### DIFF
--- a/.github/workflows/management-pack-ci.yml
+++ b/.github/workflows/management-pack-ci.yml
@@ -1,0 +1,130 @@
+name: Management Pack CI
+
+on:
+  pull_request:
+    paths:
+      - "Management Pack/**"
+      - ".github/workflows/management-pack-ci.yml"
+  workflow_dispatch:
+
+jobs:
+  sdk-validation:
+    runs-on: ${{ vars.MP_CI_RUNNER || 'ubuntu-latest' }}
+    env:
+      VENV_DIR: ${{ runner.temp }}/vcf-mp-sdk-venv
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Create isolated virtual environment
+        run: python -m venv "$VENV_DIR"
+
+      - name: Install SDK tooling in venv
+        run: |
+          source "$VENV_DIR/bin/activate"
+          python -m pip install --upgrade pip
+          pip install -r "Management Pack/requirements.txt"
+
+      - name: Validate adapter definition with SDK mp-test
+        run: |
+          source "$VENV_DIR/bin/activate"
+          mp-test -p "Management Pack" adapter_definition
+
+      - name: Cleanup virtual environment
+        if: always()
+        run: rm -rf "$VENV_DIR"
+
+  sdk-integration-smoke-test:
+    runs-on: ${{ vars.MP_CI_RUNNER || 'ubuntu-latest' }}
+    needs: sdk-validation
+    if: ${{ secrets.VCF_OPS_HOST != '' && secrets.VCF_OPS_USERNAME != '' && secrets.VCF_OPS_PASSWORD != '' && secrets.VCENTER_HOST != '' && secrets.VCENTER_USERNAME != '' && secrets.VCENTER_PASSWORD != '' }}
+    env:
+      VENV_DIR: ${{ runner.temp }}/vcf-mp-sdk-venv
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Create isolated virtual environment
+        run: python -m venv "$VENV_DIR"
+
+      - name: Install SDK tooling in venv
+        run: |
+          source "$VENV_DIR/bin/activate"
+          python -m pip install --upgrade pip
+          pip install -r "Management Pack/requirements.txt"
+
+      - name: Backup repository connection files
+        shell: bash
+        run: |
+          cp "Management Pack/connections.json" "$RUNNER_TEMP/connections.json.bak" || true
+
+      - name: Create CI SDK connection profile
+        shell: bash
+        env:
+          VCF_OPS_HOST: ${{ secrets.VCF_OPS_HOST }}
+          VCF_OPS_USERNAME: ${{ secrets.VCF_OPS_USERNAME }}
+          VCF_OPS_PASSWORD: ${{ secrets.VCF_OPS_PASSWORD }}
+          VCENTER_HOST: ${{ secrets.VCENTER_HOST }}
+          VCENTER_USERNAME: ${{ secrets.VCENTER_USERNAME }}
+          VCENTER_PASSWORD: ${{ secrets.VCENTER_PASSWORD }}
+          VCENTER_PORT: ${{ vars.VCENTER_PORT || '443' }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          connections = {
+            "suite_api_hostname": os.environ["VCF_OPS_HOST"],
+            "suite_api_username": os.environ["VCF_OPS_USERNAME"],
+            "suite_api_password": os.environ["VCF_OPS_PASSWORD"],
+            "connections": [
+              {
+                "name": "ci",
+                "identifiers": {
+                  "host": os.environ["VCENTER_HOST"],
+                  "port": os.environ["VCENTER_PORT"]
+                },
+                "credential": {
+                  "user": os.environ["VCENTER_USERNAME"],
+                  "password": os.environ["VCENTER_PASSWORD"]
+                }
+              }
+            ]
+          }
+
+          Path("Management Pack/connections.json").write_text(json.dumps(connections, indent=2))
+          PY
+
+      - name: Run SDK connect smoke test
+        run: |
+          source "$VENV_DIR/bin/activate"
+          mp-test -p "Management Pack" -c ci connect
+
+      - name: Run SDK collect smoke test
+        run: |
+          source "$VENV_DIR/bin/activate"
+          mp-test -p "Management Pack" -c ci collect -n 1 -w 5m
+
+      - name: Restore repository connection files
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/connections.json.bak" ]; then
+            mv "$RUNNER_TEMP/connections.json.bak" "Management Pack/connections.json"
+          else
+            rm -f "Management Pack/connections.json"
+          fi
+
+      - name: Cleanup virtual environment
+        if: always()
+        run: rm -rf "$VENV_DIR"

--- a/README.md
+++ b/README.md
@@ -56,3 +56,37 @@ Additional Properties & Metrics:
 - Virtual Machine Snapshot Count
   
 Login to VMware Hands-on Lab, then test drive [this MP](https://labs.hol.vmware.com/HOL/catalog/lab/26848). [Abhijit Timble](https://www.linkedin.com/in/abhijit-timble-75878514/) has installed it so you can evaluate it before deciding in your environment.
+
+## GitHub Actions automation for Management Pack testing
+
+A workflow is available at `.github/workflows/management-pack-ci.yml` to automate Management Pack validation in CI/CD using the SDK-native `mp-test` tool.
+
+### How this aligns with the SDK `mp-test` function
+- Uses `mp-test adapter_definition` to validate the adapter definition through the same SDK harness used during normal Management Pack development.
+- Uses `mp-test connect` to exercise the adapter test-connection path.
+- Uses `mp-test collect` to run a collection cycle and validate runtime behavior through the SDK containerized execution path.
+- Uses a generated `connections.json` profile in CI so `mp-test` receives identifiers, credentials, and Suite API connection fields in the expected SDK format.
+
+### Required GitHub Secrets
+- `VCF_OPS_HOST`
+- `VCF_OPS_USERNAME`
+- `VCF_OPS_PASSWORD`
+- `VCENTER_HOST`
+- `VCENTER_USERNAME`
+- `VCENTER_PASSWORD`
+
+### Optional GitHub Variables
+- `VCENTER_PORT` (default: `443`)
+- `MP_CI_RUNNER` (default: `ubuntu-latest`; set to a self-hosted label such as `self-hosted`)
+
+This provides an SDK-consistent, repeatable automation path for pull requests while still supporting live smoke tests against a reachable VCF Operations instance.
+
+
+### Running cleanly on static self-hosted runners
+The workflow is designed to avoid polluting long-lived runners:
+- Creates an isolated virtual environment under `${{ runner.temp }}` for each job.
+- Installs SDK tooling only inside that venv (no global `pip` installs).
+- Removes the venv in an `if: always()` cleanup step.
+- Backs up and restores `Management Pack/connections.json` so CI secrets do not persist in the checked-out workspace after the run.
+
+If your self-hosted runner is very long-lived, you can also add periodic Docker cleanup outside this workflow (for example, scheduled host maintenance) because `mp-test` runs containerized workloads.


### PR DESCRIPTION
### Motivation
- Prevent long-lived self-hosted runner “poisoning” by making SDK installs and generated connection profiles ephemeral. 
- Ensure CI uses the SDK-native `mp-test` harness while avoiding global Python package installs on runners. 
- Make the workflow configurable so it can target either hosted runners or a self-hosted runner label without editing the YAML.

### Description
- Update `.github/workflows/management-pack-ci.yml` to create a per-job virtual environment at `${{ runner.temp }}/vcf-mp-sdk-venv`, install SDK tooling inside it, `source` the venv before running `mp-test`, and remove the venv in `if: always()` cleanup steps. 
- Add connection-file hygiene that backs up `Management Pack/connections.json` before creating a CI `connections.json` and restores (or removes) it in an `if: always()` step so generated secrets/config do not persist. 
- Add an optional workflow variable `MP_CI_RUNNER` (default `ubuntu-latest`) so the same workflow can target self-hosted runner labels; update `README.md` to document the hygiene model and the new variable. 

### Testing
- Parsed the updated workflow with `yaml.safe_load('.github/workflows/management-pack-ci.yml')` which succeeded. 
- Executed a small Python validation that reads the workflow and prints `ok`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d262c6ebc8323b14eb69885193868)